### PR TITLE
fix crash on empty message object

### DIFF
--- a/Karma.Abuse/mod/scripts/vscripts/_gift_admin.gnut
+++ b/Karma.Abuse/mod/scripts/vscripts/_gift_admin.gnut
@@ -59,34 +59,38 @@ void function Kprint(entity player, string str)
 // chathooks requires -enablechathooks in ns_startup_args.txt
 // OUR CODE
 ClServer_MessageStruct function ChatCallback(ClServer_MessageStruct message) {
-    string msg = message.message.tolower()
-    // find first char -> gotta be ! to recognize command
-    if (format("%c", msg[0]) == "!") {
-        printl("Chat Command Found")
-        // command
-        msg = msg.slice(1) // remove !
-        string cmd
-        array<string> msgArr = split(msg, " ") // split at space, [0] = command
-        try{
-            cmd = msgArr[0] // save command
-        }
-        catch(e){
-            return message
-        }
-        msgArr.remove(0) // remove command from args
+	try {
+		string msg = message.message.tolower()
+		// find first char -> gotta be ! to recognize command
+		if (format("%c", msg[0]) == "!") {
+			printl("Chat Command Found")
+			// command
+			msg = msg.slice(1) // remove !
+			string cmd
+			array<string> msgArr = split(msg, " ") // split at space, [0] = command
+			try{
+				cmd = msgArr[0] // save command
+			}
+			catch(e){
+				return message
+			}
+			msgArr.remove(0) // remove command from args
 
-        entity player = message.player
+			entity player = message.player
 
-        // command logic
-        for( int i = 0; i < KcommandArr.len(); i++ ){
-            if( KcommandArr[i].names.contains(cmd) ){
-                message.shouldBlock  = KcommandArr[i].blockMessage
-                KcommandArr[i].func(player, msgArr)
-                break
-            }
-        }
-    }
-    return message
+			// command logic
+			for( int i = 0; i < KcommandArr.len(); i++ ){
+				if( KcommandArr[i].names.contains(cmd) ){
+					message.shouldBlock  = KcommandArr[i].blockMessage
+					KcommandArr[i].func(player, msgArr)
+					break
+				}
+			}
+		}
+		return message
+	}catch(exception){
+	return message
+	}
 }
 
 void function KCommandsInit()


### PR DESCRIPTION
The format on line 65 expects that msg is not empty, however this can occur if an another mod handles a message and returns "". This bug crashed my server a couple of times. Now this fixed branch is running on my server without any related crashes